### PR TITLE
Get Godot working in container

### DIFF
--- a/extra-packages
+++ b/extra-packages
@@ -1,6 +1,6 @@
 #For rider and godot
 dotnet-sdk-8.0
-Rider needs these to start
+#Rider needs these to start
 libwayland-cursor0
 libxkbcommon0
 libxtst6 

--- a/extra-packages
+++ b/extra-packages
@@ -1,5 +1,10 @@
+#For rider and godot
 dotnet-sdk-8.0
+Rider needs these to start
 libwayland-cursor0
 libxkbcommon0
 libxtst6 
 libglib2.0-bin
+#Godot needs pipewire for audio and libdecor for CSDs
+pipewire
+libdecor-0-0


### PR DESCRIPTION
Add some packages that Godot needs for full functionality. In combination with the upgrade to Debian 13 it is now fully working on current AMD hardware
